### PR TITLE
Fix language slider

### DIFF
--- a/src/components/OptionsPanel.tsx
+++ b/src/components/OptionsPanel.tsx
@@ -21,10 +21,10 @@ export function OptionsPanel() {
       <SelectSlider
         name={t("ui.language")}
         options={[
-          { name: "de", node: "Deutsch" },
-          { name: "en", node: "English" },
+          { name: "de-DE", node: "Deutsch" },
+          { name: "en-US", node: "English" },
         ]}
-        value={i18n.language}
+        value={getLanguage(i18n.language)}
         onChange={i18n.changeLanguage}
       />
       <SelectSlider
@@ -53,4 +53,12 @@ function option(
     name,
     node: <img src={src} alt={alt} aria-label={label} title={label} />,
   };
+}
+
+function getLanguage(lang: string): "de-DE" | "en-US" {
+  if (lang === "de" || lang.startsWith("de-")) {
+    return "de-DE";
+  } else {
+    return "en-US";
+  }
 }

--- a/src/components/OptionsPanel.tsx
+++ b/src/components/OptionsPanel.tsx
@@ -56,9 +56,9 @@ function option(
 }
 
 function getLanguage(lang: string): "de-DE" | "en-US" {
-  if (lang === "de" || lang.startsWith("de-")) {
-    return "de-DE";
-  } else {
+  if (lang === "en" || lang.startsWith("en-")) {
     return "en-US";
+  } else {
+    return "de-DE";
   }
 }

--- a/src/components/OptionsPanel.tsx
+++ b/src/components/OptionsPanel.tsx
@@ -21,8 +21,8 @@ export function OptionsPanel() {
       <SelectSlider
         name={t("ui.language")}
         options={[
-          { name: "de-DE", node: "Deutsch" },
-          { name: "en-US", node: "English" },
+          { name: "de", node: "Deutsch" },
+          { name: "en", node: "English" },
         ]}
         value={i18n.language}
         onChange={i18n.changeLanguage}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -24,4 +24,9 @@ i18n
     },
   });
 
+document.documentElement.setAttribute("lang", i18n.language);
+i18n.on("languageChanged", (lng) => {
+  document.documentElement.setAttribute("lang", lng);
+});
+
 export default i18n;


### PR DESCRIPTION
Tiny PR to fix the language slider. Currently, neither language is selected until you click on one of them, because `i18n.language` defaults to `de`, not `de-DE` when the browser is set to German.