### PR TITLE
 #87 adapts admin to backend translation

### DIFF
--- a/src/admin/components/BallotView.module.scss
+++ b/src/admin/components/BallotView.module.scss
@@ -25,3 +25,12 @@
 .error {
   color: red;
 }
+
+.header {
+  h2 {
+    margin-bottom: 0px;
+  }
+  p {
+    margin-top: 0px;
+  }
+}

--- a/src/admin/components/BallotView.tsx
+++ b/src/admin/components/BallotView.tsx
@@ -31,7 +31,10 @@ function BallotView({ ballot, onDelete, onStatusChange }: BallotProps) {
 
   return (
     <div>
-      <h2>{ballot.question}</h2>
+      <div className={styles.header}>
+        <h2>{ballot.question.en}</h2>
+        <p>{ballot.question.de}</p>
+      </div>
       <p
         className={classNames(styles.status, {
           [styles.active]: ballot.running,
@@ -44,14 +47,16 @@ function BallotView({ ballot, onDelete, onStatusChange }: BallotProps) {
         <thead>
           <tr>
             <th>Identifier</th>
-            <th>Label</th>
+            <th>German Label</th>
+            <th>English Label</th>
           </tr>
         </thead>
         <tbody>
           {ballot.options.map(({ identifier, label }) => (
             <tr key={identifier}>
               <td>{identifier}</td>
-              <td>{label}</td>
+              <td>{label.de}</td>
+              <td>{label.en}</td>
             </tr>
           ))}
         </tbody>

--- a/src/admin/components/VoteOption.tsx
+++ b/src/admin/components/VoteOption.tsx
@@ -47,11 +47,25 @@ function VoteOptionView({
       <WWTSInput
         aria-label="Label"
         title="Label"
-        placeholder="Label"
-        value={label}
-        onChange={(e) => onChange({ identifier, label: e.target.value })}
+        placeholder=" German Label"
+        value={label.de}
+        onChange={(e) =>
+          onChange({ identifier, label: { de: e.target.value, en: label.en } })
+        }
         className={classNames(styles.label, {
-          [styles.invalid]: showErrors && label === "",
+          [styles.invalid]: showErrors && label.de === "",
+        })}
+      />
+      <WWTSInput
+        aria-label="Label"
+        title="Label"
+        placeholder="English Label"
+        value={label.en}
+        onChange={(e) =>
+          onChange({ identifier, label: { de: label.de, en: e.target.value } })
+        }
+        className={classNames(styles.label, {
+          [styles.invalid]: showErrors && label.en === "",
         })}
       />
     </div>

--- a/src/admin/sections/BallotForm.module.scss
+++ b/src/admin/sections/BallotForm.module.scss
@@ -30,3 +30,8 @@
     background-color: var(--green-button-background);
   }
 }
+
+// i don't fucking know re
+.input {
+  margin-left: 0 !important
+}

--- a/src/admin/sections/BallotForm.tsx
+++ b/src/admin/sections/BallotForm.tsx
@@ -27,7 +27,7 @@ export function BallotForm({ payload, onFormClose }: BallotProps) {
     clearErrors,
   } = useForm<CreationBallot>({
     defaultValues: payload ?? {
-      question: "",
+      question: { de: "", en: "" },
       options: [],
       running: false,
     },
@@ -36,12 +36,17 @@ export function BallotForm({ payload, onFormClose }: BallotProps) {
   // TODO: Should be done with the validation of react-hook-form but i'm to dumb to do it
   const validateForm = useCallback(() => {
     clearErrors();
-    if (watch().question.length < 1) {
+    if (watch().question.de.length < 1 && watch().question.en.length < 1) {
       setError("question", { message: "Error: Question missing" });
     }
 
     if (
-      watch().options.some((o) => o.label.length < 1 || o.identifier.length < 1)
+      watch().options.some(
+        (o) =>
+          o.label.en.length < 1 ||
+          o.label.de.length < 1 ||
+          o.identifier.length < 1
+      )
     ) {
       setError("options", {
         message: "You have a invalid vote option",
@@ -73,10 +78,14 @@ export function BallotForm({ payload, onFormClose }: BallotProps) {
   const addVoteOption = useCallback(
     (e: FormEvent) => {
       e.preventDefault();
-      setValue("options", [...watch().options, { identifier: "", label: "" }], {
-        shouldDirty: true,
-        shouldValidate: true,
-      });
+      setValue(
+        "options",
+        [...watch().options, { identifier: "", label: { en: "", de: "" } }],
+        {
+          shouldDirty: true,
+          shouldValidate: true,
+        }
+      );
       validateForm();
     },
     [setValue, validateForm, watch]
@@ -128,11 +137,27 @@ export function BallotForm({ payload, onFormClose }: BallotProps) {
 
         <label htmlFor="question">Question:</label>
         <WWTSInput
-          id="question"
+          className={styles.input}
+          id="question.de"
           type="text"
-          value={watch().question}
+          placeholder="German Question"
+          value={watch().question.de}
           onChange={(e) => {
-            setValue("question", e.target.value, {
+            setValue("question.de", e.target.value, {
+              shouldDirty: true,
+              shouldValidate: true,
+            });
+            validateForm();
+          }}
+        />
+        <WWTSInput
+          className={styles.input}
+          id="question.en"
+          type="text"
+          placeholder="English Question"
+          value={watch().question.en}
+          onChange={(e) => {
+            setValue("question.en", e.target.value, {
               shouldDirty: true,
               shouldValidate: true,
             });

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,13 +1,13 @@
 export interface Ballot {
   _id: string;
-  question: string;
+  question: TranslatableText;
   running: boolean;
   options: VoteOption[];
 }
 
 export interface VoteOption {
   identifier: string;
-  label: string;
+  label: TranslatableText;
 }
 
 export interface TokenStatus {
@@ -23,4 +23,9 @@ export interface Jwt {
   readonly username: string;
   readonly iat: number;
   readonly exp: number;
+}
+
+interface TranslatableText {
+  de: string;
+  en: string;
 }

--- a/src/network/ballotApi.ts
+++ b/src/network/ballotApi.ts
@@ -1,4 +1,4 @@
-import { Ballot, Jwt, VoteOption } from "../models";
+import { Ballot, Jwt } from "../models";
 import { del, FetchError, get, post, put } from "./request";
 
 export async function fetchRunningBallot(): Promise<Ballot | undefined> {
@@ -50,8 +50,4 @@ export async function updateBallot(
   return await put<Ballot>(`/api/ballot/${id}`, { body, jwt });
 }
 
-export interface CreationBallot {
-  running: boolean;
-  question: string;
-  options: VoteOption[];
-}
+export type CreationBallot = Omit<Ballot, "_id">;


### PR DESCRIPTION
If you want to test this pr spin up the backend branch  [feature/translated-vote-options](https://github.com/LeoTuet/backend-we-want-to-sleep/tree/feature/translated-vote-options)  locally on port 8000 and use this vite.config on the frontend.
```
  server: {
    proxy: {
      "/api": {
        target: "http://localhost:8000",
        changeOrigin: true,
        secure: false,
        rewrite: (path) => path.replace(/^\/api/, ""),
      },
    },
  },
```